### PR TITLE
Changed lat/lon values to numbers instead of strings

### DIFF
--- a/vocabulary-ex183-jsonld.json
+++ b/vocabulary-ex183-jsonld.json
@@ -3,7 +3,7 @@
 "@context": "http://www.w3.org/ns/activitystreams",
 "type": "Place",
 "name": "San Francisco, CA",
-"longitude": "122.4167",
-"latitude": "37.7833"
+"longitude": 122.4167,
+"latitude": 37.7833
 }
    


### PR DESCRIPTION
The AS2 specification defines lat/long as xsd:float. A string is an invalid data type.