### PR TITLE
Removed invalid newlines in JSON string

### DIFF
--- a/vocabulary-ex196-jsonld.json
+++ b/vocabulary-ex196-jsonld.json
@@ -1,11 +1,8 @@
-
 {
   "@context": "http://www.w3.org/ns/activitystreams",
   "name": "A thank-you note",
   "type": "Note",
-  "content": "Thank you &lt;a href='http://sally.example.org'&gt;@sally&lt;/a&gt;
-      for all your hard work!
-      &lt;a href='http://example.org/tags/givingthanks'&gt;#givingthanks&lt;/a&gt;",
+  "content": "Thank you &lt;a href='http://sally.example.org'&gt;@sally&lt;/a&gt;for all your hard work!&lt;a href='http://example.org/tags/givingthanks'&gt;#givingthanks&lt;/a&gt;",
   "to": {
     "name": "Sally",
     "type": "Person",


### PR DESCRIPTION
The `content` string has newline characters, which will not parse with standard JSON parsers.